### PR TITLE
Changed class multiselect to multiupload

### DIFF
--- a/application/libraries/Grocery_CRUD_Multiuploader.php
+++ b/application/libraries/Grocery_CRUD_Multiuploader.php
@@ -433,7 +433,7 @@ class Grocery_CRUD_Multiuploader extends grocery_CRUD
                         <span class="qq-upload-spinner" id="ajax-loader-file" style="display:none;"></span>
 			<span id="' . $this->upload_field . '_progress-multiple" style="display:none;"></span>
 		</div>
-		<select name="' . $this->upload_field . '_files[]" multiple="multiple" size="8" class="multiselect" id="' . $this->upload_field . '_multiple_select" style="display:none;">
+		<select name="' . $this->upload_field . '_files[]" multiple="multiple" size="8" class="multiupload" id="' . $this->upload_field . '_multiple_select" style="display:none;">
 		</select>
 		<div id="' . $this->upload_field . '_list_svc" class="mutiupload_list" style="margin-top: 40px;">
 		</div>';
@@ -483,7 +483,7 @@ class Grocery_CRUD_Multiuploader extends grocery_CRUD
 				name="' . $this->upload_field . '_files[]" 
 			    multiple="multiple" 
 			        size="8" 
-			       class="multiselect" 
+			       class="multiupload" 
 				  id="' . $this->upload_field . '_multiple_select" 
                                style="display:none;">';
 


### PR DESCRIPTION
Class multiselect is used internally by Grocerycrud, so it breaks when multiselect is used together with Multiupload extension.

Reference: Field Actors in http://www.grocerycrud.com/documentation/options_functions/set_relation_n_n

![2015-08-09_092444](https://cloud.githubusercontent.com/assets/13715287/9153929/930630ac-3e78-11e5-948e-3b4de0cca8c3.jpg)
